### PR TITLE
Small fix on Checking opencv version

### DIFF
--- a/CMT.py
+++ b/CMT.py
@@ -27,7 +27,7 @@ class CMT(object):
 
 		# Initialise detector, descriptor, matcher
 		# check opencv version
-		if cv2.__version__ < 3.0:
+		if cv2.__version__.split('.')[0] < '3':
 			self.detector = cv2.FeatureDetector_create(self.DETECTOR)
 			self.descriptor = cv2.DescriptorExtractor_create(self.DESCRIPTOR)
 			self.matcher = cv2.DescriptorMatcher_create(self.MATCHER)


### PR DESCRIPTION
This is a very good idea to check version and it's very helpful for my personal project, but there is a small problem that when i am using this, it return an error, "TypeError: '<' not supported between instances of 'str' and 'float'", Hope this will fix.
Thank you for that.